### PR TITLE
Add data field to loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Will generate two different chunks, one for the home router and one for the item
 
 Generally a loader is used for simple bootstrapping of an application, along with core libraries.
 
+If two parameters are passed, the first paramter is passed to the loader runtime and maybe used as needed for initialization.
+
+```javascript
+Circus.loader({root: '/foo'}, [
+  './home',
+  './items'
+]);
+```
+
+Would pass the object containing `root` to the generated module json at runtime.
+
 ### Generated Code
 
 The loader will generate a JavaScript construct similar to the following:

--- a/lib/dependencies/require-router-listing.js
+++ b/lib/dependencies/require-router-listing.js
@@ -1,8 +1,9 @@
 var NullDependency = require('webpack/lib/dependencies/NullDependency');
 
-function RequireRouterListing(blocks, expr, resource) {
+function RequireRouterListing(data, blocks, expr, resource) {
   NullDependency.call(this);
   this.Class = RequireRouterListing;
+  this.data = data;
   this.blocks = blocks;
   this.expr = expr;
   this.range = expr.range;
@@ -55,7 +56,16 @@ RequireRouterListing.Template.prototype.apply = function(dep, source) {
     RequireRouterListing.extractMap(module, block, routeMap, content);
   }, this);
 
-  source.replace(dep.range[0], dep.range[1] - 1, '' + namespace + '.loader(__webpack_require__, ' + JSON.stringify(content) + ')');
+  if (dep.data) {
+    // Strip the root JSON object syntax so we can construct our own.
+    content = JSON.stringify(content).replace(/^\{|\}$/g, '');
+
+    // Break this into multiple components that will build around the data source component if one exists
+    source.replace(dep.range[0], dep.data.range[0] - 1, namespace + '.loader(__webpack_require__, {"data":');
+    source.replace(dep.data.range[1], dep.range[1] - 1, ',' + content + '})');
+  } else {
+    source.replace(dep.range[0], dep.range[1] - 1, namespace + '.loader(__webpack_require__, ' + JSON.stringify(content) + ')');
+  }
 };
 
 

--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -83,13 +83,16 @@ exports.prototype.apply = function(compiler) {
   });
 
   compiler.parser.plugin('call ' + namespace + '.loader', function(expr) {
+    var dependenciesIndex = expr.arguments.length > 1 ? 1 : 0;
+
     // Do not parse if no args or an empty array is passed.
-    if (!expr.arguments[0] || !expr.arguments[0].elements || !expr.arguments[0].elements.length) {
+    if (!expr.arguments[dependenciesIndex] || !expr.arguments[dependenciesIndex].elements || !expr.arguments[dependenciesIndex].elements.length) {
       this.state.compilation.warnings.push(new Error(this.state.current.resource + ':' + expr.loc.start.line + ' - No imports'));
       return;
     }
 
-    var dependenciesExpr = this.evaluateExpression(expr.arguments[0]),
+    var dataExpr = expr.arguments.length > 1 ? this.evaluateExpression(expr.arguments[0]) : undefined,
+        dependenciesExpr = this.evaluateExpression(expr.arguments[dependenciesIndex]),
         old = this.state.current;
 
     var blocks = dependenciesExpr.items.map(function(depName) {
@@ -106,7 +109,7 @@ exports.prototype.apply = function(compiler) {
       }
     }, this);
 
-    this.state.current.addDependency(new RequireRouterListing(blocks, expr, this.state.current.resource));
+    this.state.current.addDependency(new RequireRouterListing(dataExpr, blocks, expr, this.state.current.resource));
     return true;
   });
   compiler.parser.plugin('evaluate typeof ' + namespace + '.loader', function(expr) {

--- a/test/fixtures/loader-data.js
+++ b/test/fixtures/loader-data.js
@@ -1,0 +1,5 @@
+var Circus = require('circus');
+
+Circus.loader({root: '/root'}, [
+  './router1.js'
+]);

--- a/test/plugins/loader.js
+++ b/test/plugins/loader.js
@@ -283,7 +283,7 @@ describe('loader plugin', function() {
       done();
     });
   });
-  it.only('should include app data if passed', function(done) {
+  it('should include app data if passed', function(done) {
     var entry = path.resolve(__dirname + '/../fixtures/loader-data.js');
 
     var config = {

--- a/test/plugins/loader.js
+++ b/test/plugins/loader.js
@@ -147,8 +147,8 @@ describe('loader plugin', function() {
 
       // Verify the loader boilerplate
       var output = fs.readFileSync(outputDir + '/bundle.js').toString();
-      expect(output).to.match(/Circus.loader\(__webpack_require__, \{"modules":\{"1":\{"chunk":1\}\},"routes":\{"\/foo":1,"\/bar":1\}\}\);/);
-      expect(output).to.match(/Circus.loader\(__webpack_require__, \{"modules":\{"2":\{"chunk":2\}\},"routes":\{"\/foo":2,"\/bar":2\}\}\);/);
+      expect(output).to.contain('Circus.loader(__webpack_require__, {"modules":{"1":{"chunk":1}},"routes":{"/foo":1,"/bar":1}});');
+      expect(output).to.contain('Circus.loader(__webpack_require__, {"modules":{"2":{"chunk":2}},"routes":{"/foo":2,"/bar":2}});');
 
       // Verify the module map output
       var pack = JSON.parse(fs.readFileSync(outputDir + '/circus.json').toString());
@@ -304,7 +304,7 @@ describe('loader plugin', function() {
       expect(status.compilation.warnings).to.be.empty;
 
       var output = fs.readFileSync(outputDir + '/bundle.js').toString();
-      expect(output).to.match(/Circus.loader\(__webpack_require__, \{"data":\{root: '\/root'\},"modules":\{"2":\{"chunk":1\}\},"routes":\{"\/foo":2,"\/bar":2\}\}\);/);
+      expect(output).to.contain('Circus.loader(__webpack_require__, {"data":{root: \'/root\'},"modules":{"2":{"chunk":1}},"routes":{"/foo":2,"/bar":2}});');
 
       done();
     });

--- a/test/plugins/loader.js
+++ b/test/plugins/loader.js
@@ -283,6 +283,32 @@ describe('loader plugin', function() {
       done();
     });
   });
+  it.only('should include app data if passed', function(done) {
+    var entry = path.resolve(__dirname + '/../fixtures/loader-data.js');
+
+    var config = {
+      entry: entry,
+      output: {path: outputDir},
+      circusNamespace: 'Circus',
+
+      externals: {
+        'circus': 'Circus'
+      }
+    };
+    config = CircusRouter.config(config);
+    config = Circus.config(config);
+
+    webpack(config, function(err, status) {
+      expect(err).to.not.exist;
+      expect(status.compilation.errors).to.be.empty;
+      expect(status.compilation.warnings).to.be.empty;
+
+      var output = fs.readFileSync(outputDir + '/bundle.js').toString();
+      expect(output).to.match(/Circus.loader\(__webpack_require__, \{"data":\{root: '\/root'\},"modules":\{"2":\{"chunk":1\}\},"routes":\{"\/foo":2,"\/bar":2\}\}\);/);
+
+      done();
+    });
+  });
   it('should handle typeof', function(done) {
     var config = {
       entry: __dirname + '/../fixtures/eval-loader.js',


### PR DESCRIPTION
Allows client code to pass data to the application framework at runtime. If
two parameters are provided, the first parameter will be passed verbatim to
the runtime loader. This allows for any code construct as long as the runtime
supports it.